### PR TITLE
Allow any option in Isotope to be set through a helper function.

### DIFF
--- a/isotope.js
+++ b/isotope.js
@@ -148,6 +148,9 @@ Template.isotope.onRendered(function () {
 	}
 	// console.log({isotope:options});
 	
+	// This allows the user to set any and override any options.
+	_.extend( options, this.data.optionsForIsotope );
+
 	$el.isotope(options);
 	
 	ref2 = $(this.find('.isotopeElementContainer'));


### PR DESCRIPTION
This a surgical alternative to #7. Changes only what is needed.
